### PR TITLE
feat: ✨ Add GET /stores with query parameters + GET / stores/:uuid

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4,6 +4,16 @@ FORMAT: 1A
 
 *This API Blueprint is subject to change due to technology restrictions, performance optimizations or changing requirements.*
 
+## Filtering
+
+### Filtering
+
+This API can filter returned collections based on provided query parameters. Virtually any model field can be used as a filter (except sensible data)
+
+For example, when requesting a list of movies from the /movies endpoint, you may want to limit these to only those of drama genre. This could be accomplished with a request like `GET /movies?genre=drama`. Here, genre is a query parameter that implements a filter.
+
+Searchable list of fields are defined in data stuctures section
+
 # HTTP Methods
 
 This API uses HTTP verbs (methods) as following:
@@ -44,6 +54,7 @@ This API uses HTTP status codes to communicate with the API consumer.
 + `400 Bad Request` - Malformed request; form validation errors.
 + `401 Unauthorized` - When no or invalid authentication details are provided.
 + `403 Forbidden` - When authentication succeeded but authenticated user doesn't have access to the resource.
++ `404 Not Found` - When a non-existent resource is requested.
 
 # Group Photo
 
@@ -100,7 +111,7 @@ Creates a new photo.
     + Attributes ([JWT])
 
 ## Store Login [/stores/login]
- 
+
 ### Retrieve a Token [POST]
 
 Allows to retrieve a valid JSON Web Token.
@@ -118,6 +129,28 @@ Allows to retrieve a valid JSON Web Token.
 
 + Response 200 (application/json; charset=utf-8)
     + Attributes ([JWT])
+
+## Stores [/stores]
+
+### List all Stores  [GET]
+
+Returns a list of stores. The stores are returned in sorter order, with the most recently created stores appearing first.
+
+**Searcheable fields**
++ name
++ email
++ slug
+
+**Endpoint information**
+
+| Requires authentication | Has restricted scope |
+|-------------------------|----------------------|
+| No                      | No                   |
+
++ Request (application/json; charset=utf-8)
+
++ Response 200 (application/json; charset=utf-8)
+    + Attributes ([Store])
 
 # Group Customers
 
@@ -180,6 +213,7 @@ Allows to retrieve a valid JSON Web Token.
 + name: `Let's Eat` (string, required) - Name of the store.
 + email: `hello@letseat.co` (string, required) - Email of the store.
 + phoneNumber: `0134724336` (number, required) - Phone number of the store.
++ slug: `lets-eat-7d6ae7c69f` (string, required) - Slug of the store.
 + password: `f8e2cfacc6` (string, required) - Password of the store.
 + imageUrl: `https://some.cdn.com/img.png` (string, optional) - Main image URL of the store.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -132,7 +132,7 @@ Allows to retrieve a valid JSON Web Token.
 
 ## Stores [/stores]
 
-### List all Stores  [GET]
+### List all Stores [GET]
 
 Returns a list of stores. The stores are returned in sorter order, with the most recently created stores appearing first.
 
@@ -140,6 +140,26 @@ Returns a list of stores. The stores are returned in sorter order, with the most
 + name
 + email
 + slug
+
+**Endpoint information**
+
+| Requires authentication | Has restricted scope |
+|-------------------------|----------------------|
+| No                      | No                   |
+
++ Request (application/json; charset=utf-8)
+
++ Response 200 (application/json; charset=utf-8)
+    + Attributes ([Store])
+
+## Stores [/stores/{uuid}]
+
++ Parameters
+    + uuid: `890df35b-3e94-4c68-9553-42976cfd5612` (string) - UUID of the store.
+
+### Retrieve a Store [GET]
+
+Retrieve the details of an existing Store.
 
 **Endpoint information**
 

--- a/src/app/common/decorators/search.decorator.ts
+++ b/src/app/common/decorators/search.decorator.ts
@@ -1,0 +1,16 @@
+import {createParamDecorator, UnprocessableEntityException} from '@nestjs/common';
+import {Request} from 'express';
+import {QueryParams} from '../../store/enums/stores-search-params.enum';
+import {isObjectEmpty} from '@shared';
+
+// @TODO Handle multiple params search
+export const Search: Function = createParamDecorator((_: string, req: Request) => {
+	if (isObjectEmpty(req.query)) {
+		return false;
+	}
+	const isQueryValid = Object.values(QueryParams).some(val => val === Object.keys(req.query)[0]);
+	if (isQueryValid) {
+		return req.query;
+	}
+	throw new UnprocessableEntityException('Search query is not valid');
+});

--- a/src/app/common/interceptors/timeout.interceptor.ts
+++ b/src/app/common/interceptors/timeout.interceptor.ts
@@ -1,0 +1,11 @@
+/* tslint:disable:no-unused */
+import {Injectable, NestInterceptor, ExecutionContext} from '@nestjs/common';
+import {Observable} from 'rxjs';
+import {timeout} from 'rxjs/operators';
+
+@Injectable()
+export class TimeoutInterceptor implements NestInterceptor {
+	intercept(context: ExecutionContext, call$: Observable<any>): Observable<any> {
+		return call$.pipe(timeout(5000));
+	}
+}

--- a/src/app/common/interceptors/transform.interceptor.ts
+++ b/src/app/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,15 @@
+/* tslint:disable:no-unused */
+import {Injectable, NestInterceptor, ExecutionContext} from '@nestjs/common';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+export interface Response<T> {
+	data: T;
+}
+
+@Injectable()
+export class TransformInterceptor<T> implements NestInterceptor<T, Response<T>> {
+	intercept(context: ExecutionContext, call$: Observable<T>): Observable<Response<T>> {
+		return call$.pipe(map(data => ({data})));
+	}
+}

--- a/src/app/core.module.ts
+++ b/src/app/core.module.ts
@@ -3,7 +3,10 @@ import {TypeOrmModule} from '@nestjs/typeorm';
 import {PhotoModule} from '@photo';
 import {AppModule} from './app.module';
 import {StoreModule} from '@store';
-import {CustomerModule} from './customer/customer.module';
+import {CustomerModule} from '@customer';
+import {APP_INTERCEPTOR} from '@nestjs/core';
+import {TimeoutInterceptor} from './common/interceptors/timeout.interceptor';
+import {TransformInterceptor} from './common/interceptors/transform.interceptor';
 
 @Module({
 	imports: [TypeOrmModule.forRoot(),
@@ -11,6 +14,16 @@ import {CustomerModule} from './customer/customer.module';
 		PhotoModule,
 		StoreModule,
 		CustomerModule
+	],
+	providers: [
+		{
+			provide: APP_INTERCEPTOR,
+			useClass: TimeoutInterceptor,
+		},
+		{
+			provide: APP_INTERCEPTOR,
+			useClass: TransformInterceptor,
+		},
 	],
 })
 export class CoreModule {

--- a/src/app/store/__tests__/mocks/index.ts
+++ b/src/app/store/__tests__/mocks/index.ts
@@ -1,5 +1,6 @@
 import {CreateStoreDto} from '@store';
 import {LoginStoreDto} from '../../dtos';
+
 export const storeRepository = {
 	data: [
 		{
@@ -43,6 +44,9 @@ export const storeService = {
 	},
 	getPassword: async (data: any) => {
 		return storeRepository.data.find(store => store.password === data.password);
+	},
+	findByQueryParams: async (query: any) => {
+		return storeRepository.data.find(store => store.name === query);
 	}
 };
 

--- a/src/app/store/__tests__/mocks/index.ts
+++ b/src/app/store/__tests__/mocks/index.ts
@@ -37,6 +37,7 @@ export const storeRepository = {
 
 export const storeService = {
 	createOne: async (store: any) => Promise.resolve(storeRepository.data.push(store)),
+	findAll: async () => Promise.resolve(storeRepository.data),
 	findOneByEmail: async (data: any) => {
 		return storeRepository.data.find(store => store.email === data.email);
 	},

--- a/src/app/store/__tests__/store.controller.spec.ts
+++ b/src/app/store/__tests__/store.controller.spec.ts
@@ -4,8 +4,6 @@ import * as mocks from './mocks';
 import {getRepositoryToken} from '@nestjs/typeorm';
 import {CommandBus} from '@nestjs/cqrs';
 import {AuthService} from '@auth';
-import {authService} from './mocks';
-import {async} from 'rxjs/internal/scheduler/async';
 
 describe('StoreController', () => {
 	let storeController: StoreController;
@@ -38,7 +36,21 @@ describe('StoreController', () => {
 	describe('get()', () => {
 		it('should return an array of Store', async () => {
 			jest.spyOn(storeService, 'findAll').mockImplementation(() => mocks.storeRepository.data);
-			expect(await storeController.get()).toBe(mocks.storeRepository.data);
+			expect(await storeController.get(null)).toBe(mocks.storeRepository.data);
+		});
+	});
+
+	describe('getOneByUuid()', () => {
+		it('should return an array of Store', async () => {
+			jest.spyOn(storeService, 'findOneByUuid').mockImplementation(() => mocks.storeRepository.data[0].uuid);
+			expect(await storeController.getOneByUuid('9c1e887c-4a77-47ca-a572-c9286d6b7cea')).toBe(mocks.storeRepository.data[0].uuid);
+		});
+	});
+
+	describe('get(queryParams)', () => {
+		it('should return an array of Store', async () => {
+			jest.spyOn(storeService, 'findByQueryParams').mockImplementation(() => mocks.storeRepository.data);
+			expect(await storeController.get({name: 'Burger King'})).toBe(mocks.storeRepository.data);
 		});
 	});
 });

--- a/src/app/store/__tests__/store.controller.spec.ts
+++ b/src/app/store/__tests__/store.controller.spec.ts
@@ -34,4 +34,11 @@ describe('StoreController', () => {
 			expect(await storeController.register(mocks.storeCreateDto)).toBe(mocks.jwtPayload);
 		});
 	});
+
+	describe('get()', () => {
+		it('should return an array of Store', async () => {
+			jest.spyOn(storeService, 'findAll').mockImplementation(() => mocks.storeRepository.data);
+			expect(await storeController.get()).toBe(mocks.storeRepository.data);
+		});
+	});
 });

--- a/src/app/store/__tests__/store.e2e.spec.ts
+++ b/src/app/store/__tests__/store.e2e.spec.ts
@@ -22,6 +22,14 @@ describe('Store', () => {
 		await app.init();
 	});
 
+	describe('GET /', () => {
+		it('should return a HTTP 200 status code when successful', () => {
+			return request(app.getHttpServer())
+				.get('/stores')
+				.expect(200);
+		});
+	});
+
 	describe('POST /register', () => {
 		it('should return a HTTP 201 status code when successful', () => {
 			return request(app.getHttpServer())

--- a/src/app/store/__tests__/store.e2e.spec.ts
+++ b/src/app/store/__tests__/store.e2e.spec.ts
@@ -30,12 +30,32 @@ describe('Store', () => {
 		});
 	});
 
+	describe('GET /?term=search', () => {
+		it('should return a HTTP 200 status code when successful', () => {
+			return request(app.getHttpServer())
+				.get('/stores?name=BurgerKing')
+				.expect(200);
+		});
+		it('should return a HTTP 422 status code when incorrect', () => {
+			return request(app.getHttpServer())
+				.get('/stores?incorrect=BurgerKing')
+				.expect(422);
+		});
+	});
+
 	describe('POST /register', () => {
 		it('should return a HTTP 201 status code when successful', () => {
 			return request(app.getHttpServer())
 				.post('/stores/register')
 				.send(mocks.storeCreateDto)
 				.expect(201);
+		});
+
+		it('should return a HTTP 500 status code when failed', () => {
+			return request(app.getHttpServer())
+				.post('/stores/register')
+				.send({})
+				.expect(500);
 		});
 	});
 

--- a/src/app/store/__tests__/store.service.spec.ts
+++ b/src/app/store/__tests__/store.service.spec.ts
@@ -20,6 +20,13 @@ describe('StoreController', () => {
 		storeService = module.get<StoreService>(StoreService);
 	});
 
+	describe('findAll()', () => {
+		it('should return an array of Stores', async () => {
+			jest.spyOn(storeService, 'findAll').mockImplementation(() => mocks.storeRepository.data);
+			expect(await storeService.findAll()).toBe(mocks.storeRepository.data);
+		});
+	});
+
 	describe('createOne()', () => {
 		it('should return a JWT', async () => {
 			jest.spyOn(storeService, 'createOne').mockImplementation(() => mocks.jwtPayload);

--- a/src/app/store/__tests__/store.service.spec.ts
+++ b/src/app/store/__tests__/store.service.spec.ts
@@ -47,4 +47,11 @@ describe('StoreController', () => {
 			expect(await storeService.getPassword(mocks.storeLoginDto)).toBe(mocks.storeRepository.data[0].password);
 		});
 	});
+
+	describe('findByQueryParameters()', () => {
+		it('should return an array of Store when successful', async () => {
+			jest.spyOn(storeService, 'findByQueryParams').mockImplementation(() => mocks.storeRepository.data[0]);
+			expect(await storeService.findByQueryParams({name: 'BurgerKing'})).toBe(mocks.storeRepository.data[0]);
+		});
+	});
 });

--- a/src/app/store/enums/stores-search-params.enum.ts
+++ b/src/app/store/enums/stores-search-params.enum.ts
@@ -1,0 +1,5 @@
+export enum QueryParams {
+	name = 'name',
+	email = 'email',
+	slug = 'slug'
+}

--- a/src/app/store/queries/get-store-by-uuid.query.ts
+++ b/src/app/store/queries/get-store-by-uuid.query.ts
@@ -1,0 +1,11 @@
+import {ICommand} from '@nestjs/cqrs';
+import {Store} from '@store';
+
+export class GetStoreByUuidQuery extends Store implements ICommand {
+	readonly uuid: string;
+
+	constructor(uuid: string) {
+		super();
+		this.uuid = uuid;
+	}
+}

--- a/src/app/store/queries/get-stores-by-query-params.query.ts
+++ b/src/app/store/queries/get-stores-by-query-params.query.ts
@@ -1,0 +1,8 @@
+import {ICommand} from '@nestjs/cqrs';
+import {Store} from '@store';
+
+export class GetStoresByQueryParamsQuery extends Store implements ICommand {
+	constructor(args: any) {
+		super(args);
+	}
+}

--- a/src/app/store/queries/get-stores.query.ts
+++ b/src/app/store/queries/get-stores.query.ts
@@ -1,0 +1,5 @@
+import {ICommand} from '@nestjs/cqrs';
+import {Store} from '@store';
+
+export class GetStoresQuery extends Store implements ICommand {
+}

--- a/src/app/store/queries/handlers/get-store-by-query-params.handler.ts
+++ b/src/app/store/queries/handlers/get-store-by-query-params.handler.ts
@@ -1,0 +1,25 @@
+import {EventPublisher, ICommandHandler, CommandHandler} from '@nestjs/cqrs';
+import {StoreRepository} from '../../repository/store.repository';
+import {Store} from '../../';
+import {getCustomRepository} from 'typeorm';
+import {NotFoundException} from '@nestjs/common';
+import {GetStoresByQueryParamsQuery} from '../get-stores-by-query-params.query';
+
+@CommandHandler(GetStoresByQueryParamsQuery)
+export class GetStoresByQueryParamsHandler implements ICommandHandler<GetStoresByQueryParamsQuery> {
+	constructor(private readonly repository: StoreRepository, private readonly publisher: EventPublisher) {
+	}
+
+	async execute(command: GetStoresByQueryParamsQuery, resolve: (value?) => void) {
+		const storeRepository = getCustomRepository(StoreRepository);
+		const store = Store.register(command);
+
+		try {
+			const stores = await storeRepository.findByQueryParams(store);
+			return stores.length !== 0 ? resolve(stores) : resolve(Promise.reject(new NotFoundException('Resource not found')));
+		} catch (err) {
+			err.message = 'Resource not found';
+			resolve(Promise.reject(new NotFoundException(err.message)));
+		}
+	}
+}

--- a/src/app/store/queries/handlers/get-store-by-uuid.handler.ts
+++ b/src/app/store/queries/handlers/get-store-by-uuid.handler.ts
@@ -1,0 +1,26 @@
+import {EventPublisher, ICommandHandler, CommandHandler, AggregateRoot} from '@nestjs/cqrs';
+import {StoreRepository} from '../../repository/store.repository';
+import {Store} from '../../';
+import {getCustomRepository} from 'typeorm';
+import {GetStoreByUuidQuery} from '../get-store-by-uuid.query';
+import {NotFoundException} from '@nestjs/common';
+
+@CommandHandler(GetStoreByUuidQuery)
+export class GetStoreByUuidHandler implements ICommandHandler<GetStoreByUuidQuery> {
+	constructor(private readonly repository: StoreRepository, private readonly publisher: EventPublisher) {
+	}
+
+	async execute(command: GetStoreByUuidQuery, resolve: (value?) => void) {
+		const storeRepository = getCustomRepository(StoreRepository);
+		const store = Store.register(command);
+		try {
+			const storeFound = this.publisher.mergeObjectContext(
+				await storeRepository.findOneByUuid(store.uuid) as AggregateRoot
+			);
+			resolve(storeFound);
+		} catch (err) {
+			err.message = 'Resource not found';
+			resolve(Promise.reject(new NotFoundException(err.message)));
+		}
+	}
+}

--- a/src/app/store/queries/handlers/get-stores.handler.ts
+++ b/src/app/store/queries/handlers/get-stores.handler.ts
@@ -1,0 +1,20 @@
+/* tslint:disable:no-unused */
+import {EventPublisher, ICommandHandler, CommandHandler} from '@nestjs/cqrs';
+import {StoreRepository} from '../../repository/store.repository';
+import {GetStoresQuery} from '../get-stores.query';
+
+@CommandHandler(GetStoresQuery)
+export class GetStoresHandler implements ICommandHandler<GetStoresQuery> {
+	constructor(private readonly repository: StoreRepository, private readonly publisher: EventPublisher) {
+	}
+
+	async execute(command: GetStoresQuery, resolve: (value?) => void) {
+		try {
+			const storesSelect = await this.repository.find();
+			resolve(storesSelect.map(({id, ...columns}) => columns));
+			resolve(command);
+		} catch (err) {
+			resolve(Promise.reject((err.message)));
+		}
+	}
+}

--- a/src/app/store/queries/handlers/index.ts
+++ b/src/app/store/queries/handlers/index.ts
@@ -2,10 +2,12 @@ import {GetStoreByEmailHandler} from './get-store-by-email.handler';
 import {GetStorePasswordHandler} from './get-store-password.handler';
 import {GetStoresHandler} from './get-stores.handler';
 import {GetStoreByUuidHandler} from './get-store-by-uuid.handler';
+import {GetStoresByQueryParamsHandler} from './get-store-by-query-params.handler';
 
 export const StoreQueryHandlers = [
 	GetStoreByEmailHandler,
 	GetStorePasswordHandler,
 	GetStoresHandler,
-	GetStoreByUuidHandler
+	GetStoreByUuidHandler,
+	GetStoresByQueryParamsHandler
 ];

--- a/src/app/store/queries/handlers/index.ts
+++ b/src/app/store/queries/handlers/index.ts
@@ -1,9 +1,11 @@
 import {GetStoreByEmailHandler} from './get-store-by-email.handler';
 import {GetStorePasswordHandler} from './get-store-password.handler';
 import {GetStoresHandler} from './get-stores.handler';
+import {GetStoreByUuidHandler} from './get-store-by-uuid.handler';
 
 export const StoreQueryHandlers = [
 	GetStoreByEmailHandler,
 	GetStorePasswordHandler,
-	GetStoresHandler
+	GetStoresHandler,
+	GetStoreByUuidHandler
 ];

--- a/src/app/store/queries/handlers/index.ts
+++ b/src/app/store/queries/handlers/index.ts
@@ -1,4 +1,9 @@
 import {GetStoreByEmailHandler} from './get-store-by-email.handler';
 import {GetStorePasswordHandler} from './get-store-password.handler';
+import {GetStoresHandler} from './get-stores.handler';
 
-export const StoreQueryHandlers = [GetStoreByEmailHandler, GetStorePasswordHandler];
+export const StoreQueryHandlers = [
+	GetStoreByEmailHandler,
+	GetStorePasswordHandler,
+	GetStoresHandler
+];

--- a/src/app/store/repository/store.repository.ts
+++ b/src/app/store/repository/store.repository.ts
@@ -12,6 +12,10 @@ export class StoreRepository extends Repository<Store> {
 		return this.findOne({where: {email: storeEmail}});
 	}
 
+	public async findOneByUuid(storeUuid: string) {
+		return this.findOne({where: {uuid: storeUuid}});
+	}
+
 	public async getPassword(store: Store) {
 		return this.findOne({select: ['password'], where: {id: store.id}});
 	}

--- a/src/app/store/repository/store.repository.ts
+++ b/src/app/store/repository/store.repository.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:no-unused */
 import {EntityRepository, Repository, Transaction, TransactionManager} from 'typeorm';
 import {Store} from '@store';
 
@@ -12,8 +13,15 @@ export class StoreRepository extends Repository<Store> {
 		return this.findOne({where: {email: storeEmail}});
 	}
 
+	public async findByQueryParams(queryParams: any) {
+		const stores = await this.find({where: queryParams});
+		return stores.map(({id, ...attrs}) => attrs);
+	}
+
 	public async findOneByUuid(storeUuid: string) {
-		return this.findOne({where: {uuid: storeUuid}});
+		const store = await this.findOne({where: {uuid: storeUuid}});
+		delete store!.id;
+		return store;
 	}
 
 	public async getPassword(store: Store) {

--- a/src/app/store/store.controller.ts
+++ b/src/app/store/store.controller.ts
@@ -1,4 +1,4 @@
-import {Body, Controller, HttpCode, NotFoundException, Post, UnauthorizedException} from '@nestjs/common';
+import {Body, Controller, Get, HttpCode, NotFoundException, Post, UnauthorizedException} from '@nestjs/common';
 import {StoreService} from './store.service';
 import {AuthService, CryptographerService, JwtPayload} from '@auth';
 import {
@@ -11,6 +11,11 @@ import {Store} from './store.entity';
 @Controller('stores')
 export class StoreController {
 	constructor(private readonly storeService: StoreService) {
+	}
+
+	@Get()
+	public async get(): Promise<Store[]> {
+		return this.storeService.findAll();
 	}
 
 	@Post('/register')

--- a/src/app/store/store.controller.ts
+++ b/src/app/store/store.controller.ts
@@ -1,4 +1,13 @@
-import {Body, Controller, Get, HttpCode, NotFoundException, Post, UnauthorizedException} from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpCode,
+	NotFoundException,
+	Param,
+	Post,
+	UnauthorizedException
+} from '@nestjs/common';
 import {StoreService} from './store.service';
 import {AuthService, CryptographerService, JwtPayload} from '@auth';
 import {
@@ -16,6 +25,11 @@ export class StoreController {
 	@Get()
 	public async get(): Promise<Store[]> {
 		return this.storeService.findAll();
+	}
+
+	@Get(':uuid')
+	public async getOneByUuid(@Param('uuid') uuid: string): Promise<Store | any> {
+		return this.storeService.findOneByUuid(uuid);
 	}
 
 	@Post('/register')

--- a/src/app/store/store.controller.ts
+++ b/src/app/store/store.controller.ts
@@ -1,12 +1,6 @@
 import {
-	Body,
-	Controller,
-	Get,
-	HttpCode,
-	NotFoundException,
-	Param,
-	Post,
-	UnauthorizedException
+	Body, Controller, Get, HttpCode,
+	NotFoundException, Param, Post, UnauthorizedException
 } from '@nestjs/common';
 import {StoreService} from './store.service';
 import {AuthService, CryptographerService, JwtPayload} from '@auth';
@@ -16,6 +10,7 @@ import {
 } from './pipes/store.validation.pipe';
 import {CreateStoreDto, LoginStoreDto} from './dtos';
 import {Store} from './store.entity';
+import {Search} from '../common/decorators/search.decorator';
 
 @Controller('stores')
 export class StoreController {
@@ -23,12 +18,12 @@ export class StoreController {
 	}
 
 	@Get()
-	public async get(): Promise<Store[]> {
-		return this.storeService.findAll();
+	public async get(@Search() queryParams): Promise<Store[] | Store> {
+		return queryParams ? this.storeService.findByQueryParams(queryParams) : this.storeService.findAll();
 	}
 
 	@Get(':uuid')
-	public async getOneByUuid(@Param('uuid') uuid: string): Promise<Store | any> {
+	public async getOneByUuid(@Param('uuid') uuid: string) {
 		return this.storeService.findOneByUuid(uuid);
 	}
 

--- a/src/app/store/store.entity.ts
+++ b/src/app/store/store.entity.ts
@@ -4,7 +4,7 @@ import {AggregateRoot} from '@nestjs/cqrs';
 @Entity()
 @Unique(['email'])
 export class Store extends AggregateRoot {
-	@PrimaryGeneratedColumn()
+	@PrimaryGeneratedColumn({unsigned: true})
 	id: number;
 
 	@Column()

--- a/src/app/store/store.service.ts
+++ b/src/app/store/store.service.ts
@@ -9,6 +9,7 @@ import {CreateStoreDto} from '@store';
 import {GetStoreByEmailQuery} from './queries/get-store-by-email.query';
 import {GetStorePasswordQuery} from './queries/get-store-password.query';
 import {GetStoresQuery} from './queries/get-stores.query';
+import {GetStoreByUuidQuery} from './queries/get-store-by-uuid.query';
 
 @Injectable()
 export class StoreService {
@@ -25,6 +26,10 @@ export class StoreService {
 
 	public async findAll(): Promise<Store[]> {
 		return this.commandBus.execute(new GetStoresQuery());
+	}
+
+	public async findOneByUuid(uuid: string): Promise<Store> {
+		return this.commandBus.execute(new GetStoreByUuidQuery(uuid));
 	}
 
 	public async findOneByEmail(store: Store | any): Promise<Store> {

--- a/src/app/store/store.service.ts
+++ b/src/app/store/store.service.ts
@@ -8,6 +8,7 @@ import {JwtPayload} from '../auth/interfaces';
 import {CreateStoreDto} from '@store';
 import {GetStoreByEmailQuery} from './queries/get-store-by-email.query';
 import {GetStorePasswordQuery} from './queries/get-store-password.query';
+import {GetStoresQuery} from './queries/get-stores.query';
 
 @Injectable()
 export class StoreService {
@@ -20,6 +21,10 @@ export class StoreService {
 
 	public async createOne(store: CreateStoreDto): Promise<JwtPayload> {
 		return this.commandBus.execute(new CreateStoreCommand(store));
+	}
+
+	public async findAll(): Promise<Store[]> {
+		return this.commandBus.execute(new GetStoresQuery());
 	}
 
 	public async findOneByEmail(store: Store | any): Promise<Store> {

--- a/src/app/store/store.service.ts
+++ b/src/app/store/store.service.ts
@@ -10,6 +10,7 @@ import {GetStoreByEmailQuery} from './queries/get-store-by-email.query';
 import {GetStorePasswordQuery} from './queries/get-store-password.query';
 import {GetStoresQuery} from './queries/get-stores.query';
 import {GetStoreByUuidQuery} from './queries/get-store-by-uuid.query';
+import {GetStoresByQueryParamsQuery} from './queries/get-stores-by-query-params.query';
 
 @Injectable()
 export class StoreService {
@@ -30,6 +31,10 @@ export class StoreService {
 
 	public async findOneByUuid(uuid: string): Promise<Store> {
 		return this.commandBus.execute(new GetStoreByUuidQuery(uuid));
+	}
+
+	public async findByQueryParams(queryParams: object): Promise<Store | Store[]> {
+		return this.commandBus.execute(new GetStoresByQueryParamsQuery(queryParams));
 	}
 
 	public async findOneByEmail(store: Store | any): Promise<Store> {

--- a/src/shared/hooks/index.js
+++ b/src/shared/hooks/index.js
@@ -10,6 +10,7 @@ const client = new Client({
 	port: env.TEST_DB_PORT
 });
 
+const store = {};
 
 hooks.beforeAll((transactions, done) => {
 	client.connect()
@@ -20,6 +21,26 @@ hooks.beforeAll((transactions, done) => {
 			console.log(err);
 			return done(err)
 		});
+});
+
+
+// After Store Registration
+hooks.after('Stores > Store Registration > Register a new Store', (transaction, done) => {
+	client.query('SELECT * from store')
+		.then(res => {
+			store['uuid'] = res.rows[0].uuid;
+			done();
+		})
+		.catch(err => {
+			return done(err);
+		})
+});
+
+// Before retrieving Store by UUID
+hooks.before('Stores > Stores > Retrieve a Store', (transaction, done) => {
+	transaction.request.uri = `/stores/${store.uuid}`;
+	transaction.fullPath = `/stores/${store.uuid}`;
+	done();
 });
 
 hooks.afterAll((transactions, done) => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,3 +1,5 @@
 export {isNil} from './isnil.util';
 export {env} from './env.util';
+export {isUuid} from './isUuid.utils';
 export {cryptoRandomString} from './crypto-random-string.util';
+export {isObjectEmpty} from './isObjectEmpty.util';

--- a/src/shared/utils/isObjectEmpty.util.ts
+++ b/src/shared/utils/isObjectEmpty.util.ts
@@ -1,0 +1,3 @@
+export function isObjectEmpty(object: object) {
+	return !Object.keys(object).length;
+}

--- a/src/shared/utils/isUuid.utils.ts
+++ b/src/shared/utils/isUuid.utils.ts
@@ -1,0 +1,3 @@
+export function isUuid(string: string) {
+	return string.match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$');
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,12 +1,22 @@
 {
-	"extends": ["tslint-xo", "tslint-sonarts"],
-		"rules": {
-			"no-unnecessary-class": false,
-			"no-implicit-dependencies": false,
-			"no-non-null-assertion": false,
-			"no-hardcoded-credentials": false,
-			"no-identical-functions": false,
-			"variable-name": ["allow-pascal-case"],
-			"file-name-casing": false
-		}
+  "extends": [
+    "tslint-xo",
+    "tslint-sonarts"
+  ],
+  "rules": {
+    "no-unnecessary-class": false,
+    "no-implicit-dependencies": false,
+    "no-non-null-assertion": false,
+    "no-hardcoded-credentials": false,
+    "no-identical-functions": false,
+    "variable-name": [
+      "allow-pascal-case"
+    ],
+    "file-name-casing": false
+  },
+  "linterOptions": {
+    "exclude": [
+      "*.spec.ts"
+    ]
+  }
 }


### PR DESCRIPTION
**Description :**

Fixes #6 

Implemented **GET** /stores with query parameters endpoint

The searchable fields are:
- name
- email
- slug

Can be used like : 
- **GET** /stores
- **GET** /stores/:uuid
- **GET** /stores?name=BurgerKing

**Types of changes :**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How has this been tested ? :**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested added functionalities as usual 🙄

**Screenshots (if appropriate) :**

**Checklist :**
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have documented my code
- [x] I have made corresponding changes to the API Blueprint documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
